### PR TITLE
Remove potential conflicts between linter and formatter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,4 +41,7 @@ ignore = [
     # Annotations.
     "ANN101",
     "ANN102",
+    # Conflicts with ruff format
+    "COM812",
+    "ISC001",
 ]


### PR DESCRIPTION
This is just resolving this warning from ruff:

```
warning: The following rules may cause conflicts when used with the formatter: `COM812`, `ISC001`. To avoid unexpected behavior, we recommend disabling these rules, either by removing them from the `select` or `extend-select` configuration, or adding them to the `ignore` configuration
```