### PR TITLE
Don't use tini anymore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 # syntax=docker/dockerfile:1
 FROM python:3.12-slim
 
-# https://github.com/krallin/tini
-ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini /tini
-RUN chmod +x /tini
-
 # copied from https://docs.docker.com/language/python/containerize/
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
@@ -28,6 +24,7 @@ USER appuser
 EXPOSE 8080
 # --- end copied parts
 
+STOPSIGNAL SIGINT
+
 COPY ./app ./app
-ENTRYPOINT ["/tini", "--"]
 CMD ["python", "app"]


### PR DESCRIPTION
Unfortunately this led to our arm64 Docker image not working. I put something else in which should work, and besides people can use `--init` on `docker run` to get an init process if they want.