### PR TITLE
Fix relative import

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -2,9 +2,8 @@ import os
 
 import discord
 import dotenv
+from database import Database
 from discord import app_commands
-
-from .database import Database
 
 dotenv.load_dotenv()
 TOKEN = os.environ["TOKEN"]


### PR DESCRIPTION
I accidentally asked about doing this, forgetting that relative imports are only for packages we import, not the `__main__` we run.